### PR TITLE
Calculate CRC on every command update

### DIFF
--- a/src/OTP/report_protocol.c
+++ b/src/OTP/report_protocol.c
@@ -2695,6 +2695,14 @@ void UpdateStick20Command (u8 Status_u8, u8 ProgressBarValue_u8)
     HID_Stick20Status_st.ProgressBarValue_u8 = ProgressBarValue_u8;
 
     CopyUpdateToHIDData ();
+
+    u32 calculated_crc32;
+
+    calculated_crc32 = generateCRC(HID_GetReport_Value_tmp);
+    HID_GetReport_Value_tmp[OUTPUT_CRC_OFFSET] = calculated_crc32 & 0xFF;
+    HID_GetReport_Value_tmp[OUTPUT_CRC_OFFSET + 1] = (calculated_crc32 >> 8) & 0xFF;
+    HID_GetReport_Value_tmp[OUTPUT_CRC_OFFSET + 2] = (calculated_crc32 >> 16) & 0xFF;
+    HID_GetReport_Value_tmp[OUTPUT_CRC_OFFSET + 3] = (calculated_crc32 >> 24) & 0xFF;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This code updates CRC value on each buffer update (whether it is command status change or progress bar increase).

Fixes #32 

Compiled under Ubuntu 17.04 with last available there AVR32 studio (AVR32 Studio, Version: 2.6.0, 753) and with merged #30 patch.
Tested `Debug` binary with libnitrokey (current `master` with added information about invalid CRC).

#### Logs
[0.45-test-logs.zip](https://github.com/Nitrokey/nitrokey-storage-firmware/files/1033537/0.45-test-logs.zip)
Logs were taken from libnitrokey Python test runs (Storage part). Test sequence is randomized, so direct comparison is harder, but a quick listing of `WARNING` log-level messages shows no occurrence while testing this patch (`0.45_compiled-crcfix.log`) - on the contrary to previous firmware.
- 0.45_compiled.log - firmware compiled under local environment, Ubuntu, AVR32 2.6.0
- 0.45_compiled-crcfix.log - firmware with fix from this PR
- 0.45_compiled-crcfix2.log - firmware with fix from this PR - overwriting SD card test