### PR TITLE
Use system clock for local offset, not timekeeping

### DIFF
--- a/src/OTP/hotp.c
+++ b/src/OTP/hotp.c
@@ -1209,14 +1209,14 @@ time_t now;
 
     // Get the local ATMEL time
     time (&now);
-    current_time = now;
 
     if (slot_no >= NUMBER_OF_TOTP_SLOTS)
         return 0;
 
     OTP_slot *slot = (OTP_slot *) get_totp_slot_addr(slot_no);
 
-    time_min = current_time / slot->interval_or_counter;
+    // Add last time stamp from app and elapsed seconds since last set_time operation
+    time_min = (current_time + now) / slot->interval_or_counter;
 
     if (slot->type != 'T') // unprogrammed slot
         return 0;

--- a/src/OTP/report_protocol.c
+++ b/src/OTP/report_protocol.c
@@ -2176,9 +2176,12 @@ u32 new_time_minutes = (new_time - 1388534400) / 60;    // 1388534400 = 01.01.20
            CI_StringOut ("Local time set to = "); itoa (new_time,text); CI_StringOut ((char*)text);
 
            CI_StringOut (" = "); ctime_r ((time_t*)&new_time,(char*)text); CI_StringOut ((char*)text); CI_StringOut ("\r\n"); } */
-        set_time (new_time);
-
+        
+        // Reset runtime counter and store the time offset that was received from the app
+        set_time (0);
         current_time = new_time;
+
+        // Write new timestamp to Flash
         err = set_time_value (new_time_minutes);
         if (err)
         {


### PR DESCRIPTION
This uses the system clock for storing the offset since the last update only.
Unix timestamp of the `set_time` command is stored locally as `u64` to prevent year 2038 integer overrun and added to current local offset for TOTP generation.

resolves #17 

Firmware: 
[firmware.zip](https://github.com/Nitrokey/nitrokey-storage-firmware/files/3301984/firmware.zip)

