### PR TITLE
Reduce size of OTP global config to 16 Bytes

### DIFF
--- a/src/OTP/hotp.c
+++ b/src/OTP/hotp.c
@@ -1114,6 +1114,11 @@ void write_to_config (u8 * data, u8 len)
 {
     u16 dummy_u16;
 
+    if(len > GLOBAL_CONFIG_SIZE)
+    {
+        len = GLOBAL_CONFIG_SIZE;
+    }
+
     LED_GreenOn ();
 
     // copy all slot data from Flash to RAM
@@ -1272,7 +1277,6 @@ u8* get_totp_slot_addr (u8 slot_number)
 
 u32 get_slot_offset(u8 slot_number)
 {
-    const u32 GLOBAL_CONFIG_SIZE = 16;
     u32 slot_offset = sizeof(OTP_slot) * slot_number + GLOBAL_CONFIG_SIZE;
 
     //FIXME: There is no way of communicating a failure/invalid slot number now

--- a/src/OTP/hotp.c
+++ b/src/OTP/hotp.c
@@ -1272,11 +1272,15 @@ u8* get_totp_slot_addr (u8 slot_number)
 
 u32 get_slot_offset(u8 slot_number)
 {
-    const u32 global_config_offset = 64;
-    u32 slot_offset = sizeof(OTP_slot) * slot_number + global_config_offset;
+    const u32 GLOBAL_CONFIG_SIZE = 16;
+    u32 slot_offset = sizeof(OTP_slot) * slot_number + GLOBAL_CONFIG_SIZE;
 
     //FIXME: There is no way of communicating a failure/invalid slot number now
-    if(slot_offset > (2 * FLASH_PAGE_SIZE + SLOT_PAGE_SIZE - sizeof(OTP_slot))) slot_offset = global_config_offset;
+    // Check if slot fits in 3 pages (minus 12 bytes at the end for backup)
+    if(slot_offset > (2 * FLASH_PAGE_SIZE + SLOT_PAGE_SIZE - sizeof(OTP_slot)))
+    {
+            slot_offset = GLOBAL_CONFIG_SIZE;
+    }
 
     return slot_offset;
 }

--- a/src/OTP/hotp.h
+++ b/src/OTP/hotp.h
@@ -50,25 +50,6 @@ typedef enum
     FLASH_TIMEOUT
 } FLASH_Status;
 
-#define NUMBER_OF_HOTP_SLOTS 4
-#define NUMBER_OF_TOTP_SLOTS 15
-
-#define SLOT_CONFIG_DIGITS 0
-#define SLOT_CONFIG_ENTER 1
-#define SLOT_CONFIG_TOKENID 2
-#define SLOT_CONFIG_PASSWORD_USED   3
-#define SLOT_CONFIG_PASSWORD_TIMED  4
-
-#define GLOBAL_CONFIG_OFFSET  0
-/*
-   global config slot:
-
-   1b slot number bound to numlock 
-   1b slot number bound to caps lock 
-   1b slot number bound to scroll lock
-
- */
-
 #define FLASH_PAGE_SIZE 512 // AVR
 
 #define SLOT_PAGE_SIZE  500 // less than actual page, so we can copy it to backup page with additional info
@@ -81,13 +62,13 @@ Page 509        : 0x800_3FA00 : TOTP time, stores the Unix timestamp from the la
 */
 #define FLASH_START            0x80000000
 #define OTP_FLASH_START_PAGE   499
-#define SLOTS_ADDRESS         (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*0))   // 0x8003e800
-#define SLOT1_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*3))   // 0x8003
-#define SLOT2_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*4))   // 0x8003
-#define SLOT3_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*5))   // 0x8003
-#define SLOT4_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*6))   // 0x8003
-#define BACKUP_PAGE_ADDRESS   (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*7))   // (3 Pages) 0x8003
-#define TIME_ADDRESS          (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*10))   //
+#define SLOTS_ADDRESS         (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*0))
+#define SLOT1_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*3))
+#define SLOT2_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*4))
+#define SLOT3_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*5))
+#define SLOT4_COUNTER_ADDRESS (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*6))
+#define BACKUP_PAGE_ADDRESS   (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*7))
+#define TIME_ADDRESS          (FLASH_START + OTP_FLASH_START_PAGE * FLASH_PAGE_SIZE + (FLASH_PAGE_SIZE*10))
 
 /* Backup page layout:
 0x800_3F400 - 0x800_3F7F4 : 1524 Bytes : Backup Memory
@@ -100,6 +81,27 @@ Page 509        : 0x800_3FA00 : TOTP time, stores the Unix timestamp from the la
 #define BACKUP_LENGTH_OFFSET  (BACKUP_SIZE -  8)  // 504 - no flash block addr
 #define BACKUP_OK_OFFSET      (BACKUP_SIZE -  6)  // 506 - no flash block addr
 
+/* OTP Flash Page Defines:  */
+#define NUMBER_OF_HOTP_SLOTS 4
+#define NUMBER_OF_TOTP_SLOTS 15
+
+/* OTP Global Configuration: 16 Bytes at beginning of Slot pages: */
+#define GLOBAL_CONFIG_OFFSET  0
+/*
+   global config slot:
+
+   1b slot number bound to numlock
+   1b slot number bound to caps lock
+   1b slot number bound to scroll lock
+
+ */
+
+/* OTP Slot Configuration Bit Offsets: */
+#define SLOT_CONFIG_DIGITS 0
+#define SLOT_CONFIG_ENTER 1
+#define SLOT_CONFIG_TOKENID 2
+#define SLOT_CONFIG_PASSWORD_USED   3
+#define SLOT_CONFIG_PASSWORD_TIMED  4
 
 #define SECRET_LENGTH_DEFINE  40
 

--- a/src/OTP/hotp.h
+++ b/src/OTP/hotp.h
@@ -86,7 +86,8 @@ Page 509        : 0x800_3FA00 : TOTP time, stores the Unix timestamp from the la
 #define NUMBER_OF_TOTP_SLOTS 15
 
 /* OTP Global Configuration: 16 Bytes at beginning of Slot pages: */
-#define GLOBAL_CONFIG_OFFSET  0
+#define GLOBAL_CONFIG_OFFSET    0
+#define GLOBAL_CONFIG_SIZE      16
 /*
    global config slot:
 

--- a/src/OTP/hotp.h
+++ b/src/OTP/hotp.h
@@ -59,10 +59,13 @@ typedef enum
 #define SLOT_CONFIG_PASSWORD_USED   3
 #define SLOT_CONFIG_PASSWORD_TIMED  4
 
+#define GLOBAL_CONFIG_OFFSET  0
 /*
    global config slot:
 
-   1b slot sent after numlock 1b slot sent after caps lock 1b slot sent after scroll lock
+   1b slot number bound to numlock 
+   1b slot number bound to caps lock 
+   1b slot number bound to scroll lock
 
  */
 
@@ -71,8 +74,8 @@ typedef enum
 #define SLOT_PAGE_SIZE  500 // less than actual page, so we can copy it to backup page with additional info
 
 /* OTP BLOCK LAYOUT:
-Page 500 - 502  : 0x800_3E800 : OTP Slots data, contains the handling structs for each OTP slot
-Page 503 - 505  : 0x800_3EE00 : HOTP Slot counters, contains one offset counter per page for each of the HOTP slots
+Page 499 - 501  : 0x800_3E600 : OTP Slots data, contains the handling structs for each OTP slot
+Page 502 - 505  : 0x800_3EC00 : HOTP Slot counters, contains one offset counter per page for each of the HOTP slots
 Page 506 - 508  : 0x800_3F400 : Backup pages, used for temporary backup of data to flash memory
 Page 509        : 0x800_3FA00 : TOTP time, stores the Unix timestamp from the last set_time operation
 */
@@ -97,7 +100,7 @@ Page 509        : 0x800_3FA00 : TOTP time, stores the Unix timestamp from the la
 #define BACKUP_LENGTH_OFFSET  (BACKUP_SIZE -  8)  // 504 - no flash block addr
 #define BACKUP_OK_OFFSET      (BACKUP_SIZE -  6)  // 506 - no flash block addr
 
-#define GLOBAL_CONFIG_OFFSET  0
+
 #define SECRET_LENGTH_DEFINE  40
 
 #define __packed __attribute__((__packed__))

--- a/src/OTP/report_protocol.c
+++ b/src/OTP/report_protocol.c
@@ -1874,7 +1874,7 @@ u8 slot_no = report[CMD_GC_SLOT_NUMBER_OFFSET];
 
 u8 cmd_write_config (u8 * report, u8 * output)
 {
-u8 slot_tmp[64];                // this is will be the new slot contents
+u8 slot_tmp[GLOBAL_CONFIG_SIZE];                // this is will be the new slot contents
 
     memset (slot_tmp, 0, 5);
 


### PR DESCRIPTION
This reduces the size of the OTP global config field to 16 Bytes to make room for all 19 OTP slots.

fixes #91 